### PR TITLE
param_automation_and_bug_fixes

### DIFF
--- a/functions/batch_beapp_HAPPE_V3.m
+++ b/functions/batch_beapp_HAPPE_V3.m
@@ -86,7 +86,7 @@ for curr_file=1:length(grp_proc_info_in.beapp_fname_all)
         if ~all(cellfun(@isempty,eeg_final))
             file_proc_info = beapp_prepare_to_save_file('HAPPE_V3',file_proc_info, grp_proc_info_in, src_dir{1});
             if params.segment.on
-            save(strcat(file_proc_info.beapp_fname{1,1}),'eeg_w','file_proc_info');
+                                save(strcat(file_proc_info.beapp_fname{1,1}),'eeg_w','file_proc_info','-v7.3','-nocompression');
             else
             save(strcat(file_proc_info.beapp_fname{1,1}),'eeg','file_proc_info');
             end  

--- a/functions/batch_beapp_create_event_segs.m
+++ b/functions/batch_beapp_create_event_segs.m
@@ -41,8 +41,10 @@ for curr_file = 1:length(grp_proc_info_in.beapp_fname_all)
     cd(src_dir{1});
     
     if exist(grp_proc_info_in.beapp_fname_all{curr_file},'file')
-        
         load(grp_proc_info_in.beapp_fname_all{curr_file},'eeg','file_proc_info');
+        if strcmp(lastwarn,'Variable ''eeg'' not found.')
+            error('eeg variable not found for this file, check that you have continous data (and not already segmented data in your source directory')
+        end
         tic;
         
         % version control for beta testers (new fields, offset fix)

--- a/functions/batch_beapp_itpc.m
+++ b/functions/batch_beapp_itpc.m
@@ -170,6 +170,7 @@ for curr_file=1:length(grp_proc_info_in.beapp_fname_all)
                 end
 
                 % analyze desired part of segment for event related data
+               if ~isempty(eeg_itc{curr_condition,1})
                 if grp_proc_info_in.src_data_type ==2
                     try
                         analysis_win_start_t_ind = find(t{curr_condition,1} >= grp_proc_info_in.evt_analysis_win_start*1000,1,'first');
@@ -186,7 +187,7 @@ for curr_file=1:length(grp_proc_info_in.beapp_fname_all)
                 else
                     error('BEAPP: ITPC cannot be run on baseline data');
                 end
-
+               end
                 diary on;
                 % calculate output statistics selected by user on analysis
                 % window

--- a/functions/beapp_happe_V3_module_warning.m
+++ b/functions/beapp_happe_V3_module_warning.m
@@ -36,4 +36,3 @@ end
 %     end
     
 end
-end

--- a/functions/beapp_prepare_to_save_file.m
+++ b/functions/beapp_prepare_to_save_file.m
@@ -43,7 +43,7 @@ function file_proc_info = beapp_prepare_to_save_file(curr_mod,file_proc_info, gr
 cd(grp_proc_info_in.beapp_toggle_mods{curr_mod,'Module_Dir'}{1});
 
 % version control -- if file run history table doesn't exist, create
-if ~isfield(file_proc_info,'hist_run_table')
+if ~isfield(file_proc_info,'hist_run_table') || isempty(file_proc_info.hist_run_table)
     file_proc_info.hist_run_table = beapp_init_file_hist_table(grp_proc_info_in.beapp_toggle_mods.Mod_Names);
 end
 

--- a/functions/find_input_dir.m
+++ b/functions/find_input_dir.m
@@ -37,7 +37,7 @@ disp(['Running data through the ' current_module_name ' module']);
 beapp_toggle_mods_temp = beapp_toggle_mods;
 row= find(strcmp(beapp_toggle_mods_temp.Mod_Names,current_module_name));
 src_dir={''};
-if length(varargin) > 0
+if length(varargin) > 0 && beapp_toggle_mods_temp('HAPPE_V3',:).Module_On
     happe_reprocess = varargin{1};
 else
     happe_reprocess = 0;
@@ -57,7 +57,7 @@ end
 
 while (isempty(src_dir{1}) && curr_row >0)
     if isdir(beapp_toggle_mods_temp.Module_Dir{curr_row}) && ~isempty(dir([beapp_toggle_mods_temp.Module_Dir{curr_row},filesep,'*.mat']))
-        if strcmp(beapp_toggle_mods_temp.Module_Output_Type(curr_row),beapp_toggle_mods_temp.Module_Input_Type(row)) || happe_reprocess
+        if contains(beapp_toggle_mods_temp.Module_Output_Type(curr_row),beapp_toggle_mods_temp.Module_Input_Type(row)) || happe_reprocess
             src_dir = beapp_toggle_mods_temp.Module_Dir(curr_row);
             disp([current_module_name ' module : Using data from source directory ' src_dir{1}]);
         end

--- a/functions/update_file_proc_info_posthappe_v3.m
+++ b/functions/update_file_proc_info_posthappe_v3.m
@@ -21,9 +21,13 @@ catch
     disp('couldnt split params')
 end
 file_proc_info.beapp_nchans_used = length(params.chans.IDs);
-file_proc_info.net_vstruct = chan_info;
+net_vstruct_temp = chan_info; %commented out so that all channel
+%info would be preservered, and unused channels will have nan in data
 if length(file_proc_info.beapp_indx{1,1}) ~= size(chan_info,2)
-    file_proc_info.beapp_indx{1,1} = cell2mat(cellfun(@(x) str2num(x(2:end)),{file_proc_info.net_vstruct.labels},'UniformOutput',false)); % indices for electrodes being used for analysis at current time
+    file_proc_info.beapp_indx{1,1} = cell2mat(cellfun(@(x) str2num(x(2:end)),{net_vstruct_temp.labels},'UniformOutput',false)); % indices for electrodes being used for analysis at current time
+    if sum(contains({net_vstruct_temp.labels},'Cz'))==1
+        file_proc_info.beapp_indx{1,1}= [file_proc_info.beapp_indx{1,1} 129];
+    end
 end
 if  params.downsample>0
     file_proc_info.beapp_srate = params.downsample;

--- a/set_beapp_def.m
+++ b/set_beapp_def.m
@@ -109,9 +109,9 @@ grp_proc_info.src_dir={''}; %source directory containing the EEG data exported f
 grp_proc_info.beapp_genout_dir={''}; %general output directory that is used to store output when the directory that the output would normally be stored in is temporary
 
 %% initialize module flags (which modules are on and off)
-ModuleNames = {'format','prepp','filt','rsamp','ica','rereference','detrend','segment','HAPPE_V3','psd','itpc','topoplot','fooof','pac','bycycle'};
+ModuleNames = {'format','prepp','filt','rsamp','ica','rereference','detrend','HAPPE_V3','segment','psd','itpc','topoplot','fooof','pac','bycycle'};
 Module_Input_Type = {'cont','cont','cont','cont','cont','cont','cont','cont','cont','seg','seg','psd','psd','seg','seg'}'; %TODO: make output from psd 'psd'
-Module_Output_Type ={'cont','cont','cont','cont','cont','cont','cont','seg','seg','psd','out','out','out','out','out'}';
+Module_Output_Type ={'cont','cont','cont','cont','cont','cont','cont','cont or seg','seg','psd','out','out','out','out','out'}'; % note happe_v3 can output seg or cont
 
 Mod_Names=ModuleNames(:);
 Module_On = true(length(ModuleNames),1); % flag all modules on as default


### PR DESCRIPTION
Changes include:

1. Updating HAPPE_V3's output types to "seg" or "cont" and adding a warning check to batch_beapp_segment which will throw an error if users try to segment after using HAPPE but aren't providing continuous data
2. Updating the backend translation of happe v3 inputs to ensure things like baseline correction are automatically turned off if segmentation is turned off
3. Making a call to the net library so that the 10-20 channels are loaded appropriately into HAPPE 