### PR TITLE
low_density_gui_support

### DIFF
--- a/functions/batch_beapp_ica.m
+++ b/functions/batch_beapp_ica.m
@@ -116,7 +116,7 @@ for curr_file=1:length(grp_proc_info_in.beapp_fname_all)
         % select channels depending on user settings
         [chan_IDs, file_proc_info] = beapp_ica_select_channels_for_file (file_proc_info,grp_proc_info_in.src_unique_nets,...
             ica_chan_labels_in_eeglab_format,grp_proc_info_in.name_10_20_elecs,grp_proc_info_in.beapp_indx_chans_to_exclude,...
-            grp_proc_info_in.beapp_ica_run_all_10_20,grp_proc_info_in.beapp_ica_10_20_chans_lbls);
+            grp_proc_info_in.beapp_ica_run_all_10_20,grp_proc_info_in.beapp_ica_10_20_chans_lbls,grp_proc_info_in.name_selected_10_20_chans_lbls);
         
         for curr_rec_period = 1:size(eeg,2)
             

--- a/functions/beapp_ica_select_channels_for_file.m
+++ b/functions/beapp_ica_select_channels_for_file.m
@@ -33,7 +33,7 @@
 % You should receive a copy of the GNU General Public License along with
 % this program. If not, see <http://www.gnu.org/licenses/>.
 %~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-function [chan_IDs, file_proc_info] = beapp_ica_select_channels_for_file (file_proc_info,src_unique_nets, happe_additional_chans_lbls,name_10_20_elecs,chans_to_exclude,use_all_10_20,ica_10_20_chans2use)
+function [chan_IDs, file_proc_info] = beapp_ica_select_channels_for_file (file_proc_info,src_unique_nets, happe_additional_chans_lbls,name_10_20_elecs,chans_to_exclude,use_all_10_20,ica_10_20_chans2use,name_selected_10_20_elecs)
 
 % get 10-20 labels and additional user set channels for this net
 uniq_net_ind = find(strcmp(src_unique_nets, file_proc_info.net_typ{1}));
@@ -61,7 +61,7 @@ else
     end
 end
 
-[file_proc_info.net_vstruct(file_proc_info.net_10_20_elecs).labels] = name_10_20_elecs{:};
+[file_proc_info.net_vstruct(file_proc_info.net_10_20_elecs(~isnan(file_proc_info.net_10_20_elecs))).labels] = name_selected_10_20_elecs{uniq_net_ind}{:}; 
 
 if ~all(cellfun(@isempty,chans_to_exclude))
     lbls_chans_to_exclude_this_net = {file_proc_info.net_vstruct(chans_to_exclude{uniq_net_ind}).labels};

--- a/prepare_to_run_main.m
+++ b/prepare_to_run_main.m
@@ -43,7 +43,16 @@ if ~isempty(nets_to_add)
     add_nets_to_library(net_list,grp_proc_info_in.ref_net_library_options,...
         grp_proc_info_in.ref_net_library_dir, grp_proc_info_in.ref_eeglab_loc_dir,grp_proc_info_in.name_10_20_elecs);  
 end
-
+% check if current net doesn't have all of the 10-20 electrodes, correct
+% use_all_ica_10_20 if so - YB 1/25/23
+net_10_20_equiv = (net_library_options{logical(sum(cell2mat((cellfun(@(x) strcmp(net_library_options.Net_Full_Name,x),grp_proc_info_in.src_unique_nets,'UniformOutput',false))),2)),'Net_10_20_Electrode_Equivalents'});
+if grp_proc_info_in.beapp_ica_run_all_10_20 && any(sum(isnan(cell2mat(net_10_20_equiv)),2) > 0)
+    grp_proc_info_in.beapp_ica_10_20_chans_lbls = cellfun(@(x) x(~isnan(x)),net_10_20_equiv,'UniformOutput',false);
+    grp_proc_info_in.beapp_ica_run_all_10_20 = 0;
+    grp_proc_info_in.name_selected_10_20_chans_lbls = cellfun(@(x) grp_proc_info_in.name_10_20_elecs(logical(~isnan(x))),net_10_20_equiv,'UniformOutput',false);
+else
+    grp_proc_info_in.name_selected_10_20_chans_lbls = repmat(grp_proc_info_in.name_selected_10_20_chans_lbls,size(net_10_20_equiv,1),1); %Copy 10_20_labels for each unique net
+end
 %% set output directories, create temporary report
 [grp_proc_info_in,modnames,first_mod_ind] = beapp_dir_prep(grp_proc_info_in);
 diary off;

--- a/set_beapp_def.m
+++ b/set_beapp_def.m
@@ -220,6 +220,7 @@ grp_proc_info.beapp_rsamp_nsamp=[]; %number of samples after resampling
 
 %% ICA variables
 grp_proc_info.name_10_20_elecs = {'FP1','FP2','F7','F3','F4','F8','C3','C4','T5','PZ','T6','O1','O2','T3','T4','P3','P4','Fz'}; % does not include CZ
+grp_proc_info.name_selected_10_20_chans_lbls = {grp_proc_info.name_10_20_elecs}; %by default, include all 10-20, later beapp will check if current net doesn't include all and update variable
 grp_proc_info.beapp_ica_type  = 1; % 1 = ICA with MARA, 2 = HAPPE, 3 = only ICA 
 grp_proc_info.beapp_ica_run_all_10_20 = 1;
 grp_proc_info.beapp_ica_10_20_chans_lbls{1} = []; 


### PR DESCRIPTION
Allows users navigating BEAPP through GUI can use low density nets that do not contain all of the 10-20 electrodes