### PR TITLE
fixed_mff_jar_lib_not_found_bug

### DIFF
--- a/functions/batch_mff2beapp.m
+++ b/functions/batch_mff2beapp.m
@@ -97,7 +97,7 @@ for curr_file = 1:length(grp_proc_info_in.src_fname_all)
     try
         curr_file_obj = mff_getObject(com.egi.services.mff.api.MFFResourceType.kMFF_RT_MFFFile, [], full_filepath);
     catch err
-        if strcmp(err.message,'Undefined variable "com" or class "com.egi.services.mff.api.MFFResourceType.kMFF_RT_MFFFile".')
+        if strcmp(err.message,'Undefined variable "com" or class "com.egi.services.mff.api.MFFResourceType.kMFF_RT_MFFFile".') || strcmp(err.message, 'Unable to resolve the name com.egi.services.mff.api.MFFResourceType.kMFF_RT_MFFFile.')
             javaaddpath(which(grp_proc_info_in.beapp_format_mff_jar_lib));
             addpath(ref_dir);
         end


### PR DESCRIPTION
Fixed bug where running BEAPP will some times error out saying that MFF jar library not found. Added or statement to catch the error and add the right path.